### PR TITLE
Proposal: Auto-Delete reminders after timeout

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -60,7 +60,7 @@ async def on_message(message):
             if not attachment.description:
                 # Send a single random reminder message.
                 message = await message.reply(reminder_texts[random.randint(0, len(reminder_texts) - 1)])
-                await asyncio.sleep(600)
+                await asyncio.sleep(30)
                 await message.delete()
                 break
 # Load all the cogs

--- a/src/bot.py
+++ b/src/bot.py
@@ -7,6 +7,7 @@ from sys import flags
 from dotenv import load_dotenv
 import discord
 import random
+import asyncio
 
 load_dotenv()
 
@@ -54,12 +55,13 @@ async def on_message(message):
 
     attachments = message.attachments
     for attachment in attachments:
-        print(attachment)
         if attachment.content_type in image_types:
             # Check if the image has a description.
             if not attachment.description:
                 # Send a single random reminder message.
                 message = await message.reply(reminder_texts[random.randint(0, len(reminder_texts) - 1)])
+                await asyncio.sleep(600)
+                await message.delete()
                 break
 # Load all the cogs
 # Connect the bot to the discord api


### PR DESCRIPTION
My proposed change would make it so that reminders sent by the bot get auto-deleted after a set timeout (currently: 10 minutes). This would still have the intended "public shaming" effect, while reducing bot-induced spam on the server.